### PR TITLE
breaking: value -> current

### DIFF
--- a/.changeset/long-panthers-laugh.md
+++ b/.changeset/long-panthers-laugh.md
@@ -1,0 +1,5 @@
+---
+"svelte-toolbelt": minor
+---
+
+breaking change: change box `.value` to `.current`

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Initializes a writable boxed state.
 	const count = box(0);
 </script>
 
-<button onclick={() => count.value++}>
-	clicks: {count.value}
+<button onclick={() => count.current++}>
+	clicks: {count.current}
 </button>
 ```
 
@@ -40,17 +40,17 @@ Useful for passing synced reactive values across boundaries.
 	function useCounter(count: WritableBox<number>) {
 		return {
 			increment() {
-				count.value++;
+				count.current++;
 			},
 			// We pass a box that doubles the count value
-			double: box.with(() => count.value * 2)
+			double: box.with(() => count.current * 2)
 		};
 	}
 	let count = $state(0);
 	// We pass count to box.with so it stays in sync
 	const { double, increment } = useCounter(
 		box.with(
-			() => count.value,
+			() => count.current,
 			(v) => (count = v)
 		)
 	);
@@ -58,7 +58,7 @@ Useful for passing synced reactive values across boundaries.
 
 <button onclick={increment}>
 	clicks: {count}
-	double: {double.value}
+	double: {double.current}
 </button>
 ```
 
@@ -76,43 +76,43 @@ Useful for receiving arguments that may or may not be reactive.
 		return {
 			count,
 			increment() {
-				count.value++;
+				count.current++;
 			},
 			// We pass a box that doubles the count value
-			double: box.with(() => count.value * 2)
+			double: box.with(() => count.current * 2)
 		};
 	}
 	const counter1 = useCounter(1);
-	console.log(counter1.count.value); // 1
-	console.log(counter1.double.value); // 2
+	console.log(counter1.count.current); // 1
+	console.log(counter1.double.current); // 2
 	const counter2 = useCounter(box(2));
-	console.log(counter2.count.value); // 2
-	console.log(counter2.double.value); // 4
+	console.log(counter2.count.current); // 2
+	console.log(counter2.double.current); // 4
 	function useDouble(_count: number | (() => number) | ReadableBox<number>) {
 		const count = box.from(_count);
-		return box.with(() => count.value * 2);
+		return box.with(() => count.current * 2);
 	}
 	const double1 = useDouble(1);
-	console.log(double1.value); // 2
+	console.log(double1.current); // 2
 	const double2 = useDouble(box(2));
-	console.log(double2.value); // 4
-	const double3 = useDouble(() => counter1.count.value);
-	console.log(double3.value); // 2
+	console.log(double2.current); // 4
+	const double3 = useDouble(() => counter1.count.current);
+	console.log(double3.current); // 2
 </script>
 ```
 
 ### `box.flatten`
 
 Transforms any boxes within an object to reactive properties, removing the need to access each
-property with `.value`.
+property with `.current`.
 
 ```ts
 const count = box(1);
 const flat = box.flatten({
 	count,
-	double: box.with(() => count.value * 2),
+	double: box.with(() => count.current * 2),
 	increment() {
-		count.value++;
+		count.current++;
 	}
 });
 
@@ -129,11 +129,11 @@ Creates a readonly box from a writable box that remains in sync with the origina
 ```ts
 const count = box(1);
 const readonlyCount = box.readonly(count);
-console.log(readonlyCount.value); // 1
-count.value++;
-console.log(readonlyCount.value); // 2
+console.log(readonlyCount.current); // 1
+count.current++;
+console.log(readonlyCount.current); // 2
 
-readonlyCount.value = 3; // Error: Cannot assign to read only property 'value' of object
+readonlyCount.current = 3; // Error: Cannot assign to read only property 'value' of object
 ```
 
 ### `box.isBox`
@@ -152,7 +152,7 @@ Checks if a value is a `WritableBox`.
 
 ```ts
 const count = box(1);
-const double = box.with(() => count.value * 2);
+const double = box.with(() => count.current * 2);
 console.log(box.isWritableBox(count)); // true
 console.log(box.isWritableBox(double)); // false
 ```

--- a/src/lib/box/box.svelte.ts
+++ b/src/lib/box/box.svelte.ts
@@ -6,12 +6,12 @@ const isWritableSymbol = Symbol('is-writable');
 
 export type ReadableBox<T> = {
 	readonly [BoxSymbol]: true;
-	readonly value: T;
+	readonly current: T;
 };
 
 export type WritableBox<T> = ReadableBox<T> & {
 	readonly [isWritableSymbol]: true;
-	value: T;
+	current: T;
 };
 
 /**
@@ -34,7 +34,7 @@ function isWritableBox(value: unknown): value is WritableBox<unknown> {
 /**
  * Creates a writable box.
  *
- * @returns A box with a `value` property which can be set to a new value.
+ * @returns A box with a `current` property which can be set to a new value.
  * Useful to pass state to other functions.
  *
  * @see {@link https://runed.dev/docs/functions/box}
@@ -44,23 +44,23 @@ export function box<T>(): WritableBox<T | undefined>;
  * Creates a writable box with an initial value.
  *
  * @param initialValue The initial value of the box.
- * @returns A box with a `value` property which can be set to a new value.
+ * @returns A box with a `current` property which can be set to a new value.
  * Useful to pass state to other functions.
  *
  * @see {@link https://runed.dev/docs/functions/box}
  */
 export function box<T>(initialValue: T): WritableBox<T>;
 export function box(initialValue?: unknown) {
-	let value = $state(initialValue);
+	let current = $state(initialValue);
 
 	return {
 		[BoxSymbol]: true,
 		[isWritableSymbol]: true,
-		get value() {
-			return value as unknown;
+		get current() {
+			return current as unknown;
 		},
-		set value(v: unknown) {
-			value = v;
+		set current(v: unknown) {
+			current = v;
 		}
 	};
 }
@@ -69,7 +69,7 @@ export function box(initialValue?: unknown) {
  * Creates a readonly box
  *
  * @param getter Function to get the value of the box
- * @returns A box with a `value` property whose value is the result of the getter.
+ * @returns A box with a `current` property whose value is the result of the getter.
  * Useful to pass state to other functions.
  *
  * @see {@link https://runed.dev/docs/functions/box}
@@ -80,7 +80,7 @@ function boxWith<T>(getter: () => T): ReadableBox<T>;
  *
  * @param getter Function to get the value of the box
  * @param setter Function to set the value of the box
- * @returns A box with a `value` property which can be set to a new value.
+ * @returns A box with a `current` property which can be set to a new value.
  * Useful to pass state to other functions.
  *
  * @see {@link https://runed.dev/docs/functions/box}
@@ -93,10 +93,10 @@ function boxWith<T>(getter: () => T, setter?: (v: T) => void) {
 		return {
 			[BoxSymbol]: true,
 			[isWritableSymbol]: true,
-			get value() {
+			get current() {
 				return derived;
 			},
-			set value(v: T) {
+			set current(v: T) {
 				setter(v);
 			}
 		};
@@ -104,7 +104,7 @@ function boxWith<T>(getter: () => T, setter?: (v: T) => void) {
 
 	return {
 		[BoxSymbol]: true,
-		get value() {
+		get current() {
 			return getter();
 		}
 	};
@@ -114,7 +114,7 @@ function boxWith<T>(getter: () => T, setter?: (v: T) => void) {
  * Creates a box from either a static value, a box, or a getter function.
  * Useful when you want to receive any of these types of values and generate a boxed version of it.
  *
- * @returns A box with a `value` property whose value.
+ * @returns A box with a `current` property whose value.
  *
  * @see {@link https://runed.dev/docs/functions/box}
  */
@@ -164,7 +164,7 @@ type BoxFlatten<R extends Record<string, unknown>> = Expand<
  *
  * @example
  * const count = box(0)
- * const flat = box.flatten({ count, double: box.with(() => count.value) })
+ * const flat = box.flatten({ count, double: box.with(() => count.current) })
  * // type of flat is { count: number, readonly double: number }
  *
  * @see {@link https://runed.dev/docs/functions/box}
@@ -178,17 +178,17 @@ function boxFlatten<R extends Record<string, unknown>>(boxes: R): BoxFlatten<R> 
 		if (box.isWritableBox(b)) {
 			Object.defineProperty(acc, key, {
 				get() {
-					return b.value;
+					return b.current;
 				},
 				// eslint-disable-next-line ts/no-explicit-any
 				set(v: any) {
-					b.value = v;
+					b.current = v;
 				}
 			});
 		} else {
 			Object.defineProperty(acc, key, {
 				get() {
-					return b.value;
+					return b.current;
 				}
 			});
 		}
@@ -211,8 +211,8 @@ function toReadonlyBox<T>(b: ReadableBox<T>): ReadableBox<T> {
 
 	return {
 		[BoxSymbol]: true,
-		get value() {
-			return b.value;
+		get current() {
+			return b.current;
 		}
 	};
 }

--- a/src/lib/box/box.test.svelte.ts
+++ b/src/lib/box/box.test.svelte.ts
@@ -5,50 +5,50 @@ import type { MaybeBoxOrGetter } from '$lib/types.js';
 describe('box', () => {
 	test('box with initial value should be settable', () => {
 		const count = box(0);
-		expect(count.value).toBe(0);
-		count.value = 1;
-		expect(count.value).toBe(1);
+		expect(count.current).toBe(0);
+		count.current = 1;
+		expect(count.current).toBe(1);
 	});
 });
 
 describe('box.from', () => {
 	test('box of writable box should be settable', () => {
 		const count = box.from(box(0));
-		expect(count.value).toBe(0);
-		count.value = 1;
-		expect(count.value).toBe(1);
+		expect(count.current).toBe(0);
+		count.current = 1;
+		expect(count.current).toBe(1);
 	});
 
 	test('box of readable box should not be settable', () => {
 		const count = box.from(box.with(() => 0));
-		expect(count.value).toBe(0);
+		expect(count.current).toBe(0);
 		// @ts-expect-error -- we're testing that the setter is not run
-		expect(() => (count.value = 1)).toThrow();
+		expect(() => (count.current = 1)).toThrow();
 	});
 
 	test('can set box of box or value', () => {
 		const count = 0 as number | WritableBox<number>;
 		const reCount = box.from(count);
-		expect(reCount.value).toBe(0);
-		reCount.value = 1;
-		expect(reCount.value).toBe(1);
+		expect(reCount.current).toBe(0);
+		reCount.current = 1;
+		expect(reCount.current).toBe(1);
 	});
 });
 
 describe('box.with', () => {
 	test('box with getter only should return value and not be settable', () => {
 		const count = box.with(() => 0);
-		expect(count.value).toBe(0);
+		expect(count.current).toBe(0);
 		// @ts-expect-error -- we're testing that the setter is not run
-		expect(() => (count.value = 1)).toThrow();
+		expect(() => (count.current = 1)).toThrow();
 	});
 
 	test('box with state getter should be reactive', () => {
 		let value = $state(0);
 		const count = box.with(() => value);
-		expect(count.value).toBe(0);
+		expect(count.current).toBe(0);
 		value++;
-		expect(count.value).toBe(1);
+		expect(count.current).toBe(1);
 	});
 
 	test('box with getter and setter should be reactive', () => {
@@ -57,9 +57,9 @@ describe('box.with', () => {
 			() => value,
 			(v) => (value = v * 2)
 		);
-		expect(double.value).toBe(0);
-		double.value = 1;
-		expect(double.value).toBe(2);
+		expect(double.current).toBe(0);
+		double.current = 1;
+		expect(double.current).toBe(2);
 		expect(value).toBe(2);
 	});
 });
@@ -86,31 +86,31 @@ describe('box.isWritableBox', () => {
 describe('box.flatten', () => {
 	test('flattens an object of boxes', () => {
 		const count = box(0);
-		const double = box.with(() => count.value * 2);
+		const double = box.with(() => count.current * 2);
 		function increment() {
-			count.value++;
+			count.current++;
 		}
 		const flat = box.flatten({ count, double, increment });
 
 		expect(flat.count).toBe(0);
 		expect(flat.double).toBe(0);
 
-		count.value = 1;
+		count.current = 1;
 		expect(flat.count).toBe(1);
 		expect(flat.double).toBe(2);
 
 		flat.count = 2;
-		expect(count.value).toBe(2);
+		expect(count.current).toBe(2);
 		expect(flat.count).toBe(2);
-		expect(double.value).toBe(4);
+		expect(double.current).toBe(4);
 		expect(flat.double).toBe(4);
 
 		// @ts-expect-error -- we're testing that the setter is not run
 		expect(() => (flat.double = 3)).toThrow();
 
 		flat.increment();
-		expect(count.value).toBe(3);
-		expect(double.value).toBe(6);
+		expect(count.current).toBe(3);
+		expect(double.current).toBe(6);
 		expect(flat.count).toBe(3);
 		expect(flat.double).toBe(6);
 	});
@@ -123,7 +123,7 @@ describe('box.readonly', () => {
 
 		function setReadOnlyCount() {
 			// eslint-disable-next-line ts/no-explicit-any
-			(readonlyCount as any).value = 1;
+			(readonlyCount as any).current = 1;
 		}
 
 		expect(setReadOnlyCount).toThrow();
@@ -133,12 +133,12 @@ describe('box.readonly', () => {
 		const count = box(0);
 		const readonlyCount = box.readonly(count);
 
-		expect(readonlyCount.value).toBe(0);
-		count.value = 1;
-		expect(readonlyCount.value).toBe(1);
+		expect(readonlyCount.current).toBe(0);
+		count.current = 1;
+		expect(readonlyCount.current).toBe(1);
 
-		count.value = 2;
-		expect(readonlyCount.value).toBe(2);
+		count.current = 2;
+		expect(readonlyCount.current).toBe(2);
 	});
 });
 

--- a/src/lib/unbox/unbox.svelte.ts
+++ b/src/lib/unbox/unbox.svelte.ts
@@ -4,7 +4,7 @@ import { isFunction } from '$lib/internal/utils/is.js';
 
 export function unbox<T>(value: MaybeBoxOrGetter<T>): T {
 	if (box.isBox(value)) {
-		return value.value;
+		return value.current;
 	}
 
 	if (isFunction(value)) {


### PR DESCRIPTION
After using these utilities heavily in the Bits UI rewrite for Svelte 5, I often find myself having `value` properties that I want to box, resulting in situations like `select.value.value` which makes it easy to forget to add the last `.value` and just looks unpleasant.

This also aligns this project with how [Runed](https://runed.dev) handles boxed state, accessing with `.current`. 