### PR TITLE
fix: `clsx` and `style-to-object` deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 		"@sveltejs/vite-plugin-svelte": "4.0.0-next.7",
 		"@svitejs/changesets-changelog-github-compact": "^1.1.0",
 		"@types/node": "^20.12.12",
-		"clsx": "^2.1.1",
 		"csstype": "^3.1.3",
 		"eslint": "^9.7.0",
 		"eslint-config-prettier": "^9.1.0",
@@ -58,6 +57,10 @@
 		"typescript": "^5.6.2",
 		"vite": "^5.4.8",
 		"vitest": "^2.1.2"
+	},
+	"dependencies": {
+		"clsx": "^2.1.1",
+		"style-to-object": "^1.0.6"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      style-to-object:
+        specifier: ^1.0.6
+        version: 1.0.6
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.1
@@ -35,9 +42,6 @@ importers:
       '@types/node':
         specifier: ^20.12.12
         version: 20.12.12
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       csstype:
         specifier: ^3.1.3
         version: 3.1.3
@@ -62,9 +66,6 @@ importers:
       publint:
         specifier: ^0.1.9
         version: 0.1.9
-      style-to-object:
-        specifier: ^1.0.6
-        version: 1.0.6
       svelte:
         specifier: 5.0.0-next.262
         version: 5.0.0-next.262


### PR DESCRIPTION
Due to `clsx` and `style-to-object` packages moving to devDependencies within the package, newest version of `svelte-toolbelt` has been causing module resolution errors, especially in the case of `bits-ui`. With these deps as normal deps, the module resolution errors don't occur.