### PR TITLE
improve: `attachRef`

### DIFF
--- a/.changeset/khaki-worms-repeat.md
+++ b/.changeset/khaki-worms-repeat.md
@@ -1,0 +1,5 @@
+---
+"svelte-toolbelt": patch
+---
+
+improve: add optional change handler arg to `attachRef`

--- a/src/lib/utils/attach-ref.ts
+++ b/src/lib/utils/attach-ref.ts
@@ -8,6 +8,7 @@ type RefSetter<T> = (v: T) => void;
  * The ref can be either a WritableBox or a callback function.
  *
  * @param ref - Either a WritableBox to store the element in, or a callback function that receives the element
+ * @param onChange - Optional callback that fires when the ref changes
  * @returns An object with a spreadable attachment key that should be spread onto the element
  *
  * @example
@@ -18,18 +19,31 @@ type RefSetter<T> = (v: T) => void;
  * @example
  * // Using with callback
  * <div {...attachRef((node) => myNode = node)}>Content</div>
+ *
+ * @example
+ * // Using with onChange
+ * <div {...attachRef(ref, (node) => console.log(node))}>Content</div>
  */
 export function attachRef<T extends EventTarget = Element>(
-	ref: WritableBox<T | null> | RefSetter<T | null>
+	ref: WritableBox<T | null> | RefSetter<T | null>,
+	onChange?: (v: T | null) => void
 ) {
 	return {
 		[createAttachmentKey()]: (node: T) => {
 			if (box.isBox(ref)) {
 				ref.current = node;
-				return () => (ref.current = null);
+				onChange?.(node);
+				return () => {
+					ref.current = null;
+					onChange?.(null);
+				};
 			}
 			ref(node);
-			return () => ref(null);
+			onChange?.(node);
+			return () => {
+				ref(null);
+				onChange?.(null);
+			};
 		}
 	};
 }


### PR DESCRIPTION
This pull request introduces an enhancement to the `attachRef` utility function by adding an optional `onChange` callback argument. This allows developers to execute custom logic whenever the ref changes, improving flexibility and usability.

### Enhancements to `attachRef`:

* Updated the JSDoc in `src/lib/utils/attach-ref.ts` to include details about the new optional `onChange` parameter, which is a callback that fires when the ref changes. Added an example demonstrating its usage. [[1]](diffhunk://#diff-d31d1356c39cb165c0f74660a6a18ccce541c1963176553913c0eef449f0bcffR11) [[2]](diffhunk://#diff-d31d1356c39cb165c0f74660a6a18ccce541c1963176553913c0eef449f0bcffR22-R46)
* Modified the `attachRef` function to accept the `onChange` argument. The function now invokes `onChange` whenever the ref is updated or cleared, ensuring the callback is triggered appropriately.

### Documentation:

* Added a changeset file `.changeset/khaki-worms-repeat.md` to document that a patch-level change has been made to the `svelte-toolbelt` package, describing the addition of the optional change handler argument to `attachRef`.

---

I commonly use the pattern `attachRef(ref, (node) => setSomethingElse(node)` so this makes my life easier which is the whole purpose of this lib :)