### PR TITLE
fix(attachRef): only set to `null` if node is no longer in dom

### DIFF
--- a/.changeset/beige-apes-protect.md
+++ b/.changeset/beige-apes-protect.md
@@ -1,0 +1,5 @@
+---
+"svelte-toolbelt": patch
+---
+
+fix: `attachRef` setting reference values to null when node is still in DOM

--- a/src/lib/utils/attach-ref.ts
+++ b/src/lib/utils/attach-ref.ts
@@ -35,6 +35,8 @@ export function attachRef<T extends EventTarget = Element>(
 				ref.current = node;
 				untrack(() => onChange?.(node));
 				return () => {
+					// we don't want to detach the node if it's still connected
+					if ("isConnected" in node && node.isConnected) return;
 					ref.current = null;
 					onChange?.(null);
 				};
@@ -42,6 +44,8 @@ export function attachRef<T extends EventTarget = Element>(
 			ref(node);
 			untrack(() => onChange?.(node));
 			return () => {
+				// we don't want to detach the node if it's still connected
+				if ("isConnected" in node && node.isConnected) return;
 				ref(null);
 				onChange?.(null);
 			};


### PR DESCRIPTION
This fixes an issue where when other restProps update, the attachment would rerun, triggering the previous one to call its cleanup, potentially causing a brief moment of `null` even though the element reference is still connected to the DOM.

Related: https://github.com/huntabyte/bits-ui/issues/1596