### PR TITLE
fix: omit nullish values in styleToCSS

### DIFF
--- a/.changeset/dirty-clocks-vanish.md
+++ b/.changeset/dirty-clocks-vanish.md
@@ -1,0 +1,5 @@
+---
+"svelte-toolbelt": patch
+---
+
+fix: omit nullish values in styleToCSS

--- a/src/lib/utils/style-to-css.ts
+++ b/src/lib/utils/style-to-css.ts
@@ -20,7 +20,8 @@ export function styleToCSS(styleObj: object) {
 	if (!styleObj || typeof styleObj !== "object" || Array.isArray(styleObj)) {
 		throw new TypeError(`expected an argument of type object, but got ${typeof styleObj}`);
 	}
-	return Object.keys(styleObj)
-		.map((property) => `${camelToKebab(property)}: ${styleObj[property as keyof typeof styleObj]};`)
+	return Object.entries(styleObj)
+		.filter(([, value]) => value !== undefined && value !== null)
+		.map(([property, value]) => `${camelToKebab(property)}: ${value};`)
 		.join("\n");
 }


### PR DESCRIPTION
Avoid serializing undefined/null into invalid CSS which browsers will drop which could block intended styles from applying. On browsers like Firefox, it will scream in the console logs. `Error in parsing value for ‘’.  Declaration dropped.`

Examples:
- https://dynamic-sunshine-491fb3.netlify.app/
- https://github.com/t7ru/svelte-toolbelt-undefined